### PR TITLE
Added map structure.Decoder to get support for son fields of type timeTime

### DIFF
--- a/jsonhal.go
+++ b/jsonhal.go
@@ -121,6 +121,7 @@ func (h *Hal) decodeHook(f reflect.Type, t reflect.Type, data interface{}) (inte
 
 // DecodeEmbedded decodes embedded objects into a struct
 func (h *Hal) DecodeEmbedded(name string, result interface{}) (err error) {
+	var dec *mapstructure.Decoder
 	defer func() {
 		if r := recover(); r != nil {
 			err = r.(error)
@@ -134,7 +135,7 @@ func (h *Hal) DecodeEmbedded(name string, result interface{}) (err error) {
 	}
 	//setup a new decoder if not already present
 	if h.decoder == nil {
-		dec, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{Result: result, DecodeHook: h.decodeHook})
+		dec, err = mapstructure.NewDecoder(&mapstructure.DecoderConfig{Result: result, DecodeHook: h.decodeHook})
 		if err != nil {
 			panic(err)
 		}

--- a/jsonhal_test.go
+++ b/jsonhal_test.go
@@ -211,7 +211,7 @@ func TestHal(t *testing.T) {
 	assert.Equal(t, expected.String(), string(actual))
 
 	// Let's add more links and a single embedded resource
-	date, err := time.Parse(time.RFC3339, "2017-09-12T08:45:20Z")
+	date, _ := time.Parse(time.RFC3339, "2017-09-12T08:45:20Z")
 	helloWorld = &HelloWorld{ID: 1, Name: "Hello World"}
 	helloWorld.SetLink(
 		"self", // name


### PR DESCRIPTION
I've used your fork instead of the original one because I liked the idea of DecodeEmbedded. But unfortunately it failed in the very first use of that function because map structure isn't able to handle time.Time fields out of the box.

For me it was much easier to add the functionality here instead of filling the gap in map structure.
I'll appreciate it if you will merge it into your fork.

kind regards

Reinhard
